### PR TITLE
Setting to disable blank select option

### DIFF
--- a/src/fields/SingleCatField.php
+++ b/src/fields/SingleCatField.php
@@ -10,6 +10,7 @@
 
 namespace elivz\singlecat\fields;
 
+use craft\elements\db\CategoryQuery;
 use elivz\singlecat\SingleCat;
 
 use Craft;
@@ -56,6 +57,11 @@ class SingleCatField extends BaseRelationField
      * @var int|null Branch limit
      */
     public $branchLimit = 1;
+
+    /**
+     * @var bool Whether to show blank select option
+     */
+    public $showBlankOption = true;
 
     // Public Methods
     // =========================================================================
@@ -116,15 +122,28 @@ class SingleCatField extends BaseRelationField
         // Get all the categories in this group
         $categories = Category::find()->groupId($source['criteria']['groupId'])->all();
 
+        // Get the element ID of the stored category
+        /** @var CategoryQuery $value */
+        $value = $value
+            ->select(['elements.id'])
+            ->scalar();
+
+        // Check whether blank option needs to be shown
+        $storedCategoryExists = $value !== false;
+        $isFresh = $element && $element->getHasFreshContent();
+
+        $showBlankOption = $this->showBlankOption || (!$storedCategoryExists && !$isFresh);
+
         // Render the input template
         return Craft::$app->getView()->renderTemplate(
             $this->inputTemplate,
             [
                 'name' => $this->handle,
-                'value' => $value->one(),
+                'value' => $value,
                 'field' => $this,
                 'source' => $source,
                 'categories' => $categories,
+                'showBlankOption' => $showBlankOption,
             ]
         );
     }

--- a/src/fields/SingleCatField.php
+++ b/src/fields/SingleCatField.php
@@ -87,14 +87,14 @@ class SingleCatField extends BaseRelationField
     {
         if (is_array($value)) {
             /**
-             * @var Category[] $categories 
+             * @var Category[] $categories
              */
             $categories = Category::find()
                 ->siteId($this->targetSiteId($element))
                 ->id(array_values(array_filter($value)))
                 ->anyStatus()
                 ->all();
-                
+
                 // Enforce the branch limit
                 $categoriesService = Craft::$app->getCategories();
                 $categoriesService->applyBranchLimitToCategories($categories, $this->branchLimit);
@@ -120,12 +120,16 @@ class SingleCatField extends BaseRelationField
         }
 
         // Get all the categories in this group
-        $categories = Category::find()->groupId($source['criteria']['groupId'])->all();
+        $categories = Category::find()
+            ->groupId($source['criteria']['groupId'])
+            ->anyStatus()
+            ->all();
 
         // Get the element ID of the stored category
         /** @var CategoryQuery $value */
         $value = $value
             ->select(['elements.id'])
+            ->anyStatus()
             ->scalar();
 
         // Check whether blank option needs to be shown

--- a/src/templates/_components/fields/input.twig
+++ b/src/templates/_components/fields/input.twig
@@ -13,11 +13,12 @@
  */
 #}
 
-{%- set value = (value is defined and value != null ? value.id : null) %}
-
 <div class="select">
     <select id="name" name="{{ name }}[]">
-        <option value=""></option>
+        {% if showBlankOption %}
+            <option value=""></option>
+        {% endif %}
+
         {% nav cat in categories %}
             <option value="{{ cat.id }}"{% if value == cat.id %} selected{% endif %}>
                 {%- for i in 0..(cat.level-1) if i > 0 %}&ndash;&nbsp;{% endfor -%}

--- a/src/templates/_components/fields/settings.twig
+++ b/src/templates/_components/fields/settings.twig
@@ -18,5 +18,13 @@
 
 {% block fieldSettings %}
     {{ block('sourcesField') }}
+
+    {{ forms.checkboxField({
+        label: "Show blank select option"|t('single-cat'),
+        name: 'showBlankOption',
+        id: 'showBlankOption',
+        checked: field.showBlankOption,
+    }) }}
+
     {{ block('advancedSettings') }}
 {% endblock %}


### PR DESCRIPTION
This adds a field setting to disable blank select option.

When blank select option is disabled, it would still show if the stored category doesn’t exist any longer, and ensures you’re not accidentially saving a random category.

There’s another change in this pull-request, which makes disabled categories selectable just like they are in a normal Categories field. Sorry for combining the two changes here.