### PR TITLE
Add GraphQL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 1.2.2 - 2020-04-23
 
-### Added
+### Fixed
 
 - Added CategoryInterface to fix GraphQL not working with SingleCat field
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.2 - 2020-04-23
+
+- Added CategoryInterface to fix GraphQL not working with SingleCat field
+
 ## 1.2.1 - 2019-02-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 1.2.2 - 2020-04-23
 
+### Added
+
 - Added CategoryInterface to fix GraphQL not working with SingleCat field
 
 ## 1.2.1 - 2019-02-17

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This fork is only here to stay until the fix in merged back into the main repo `
 - add following to the end of you composer.json object:
 ```json
 {
-    // ... ,
+    …
     "minimum-stability": "dev",
     "prefer-stable": true,
     "repositories": [

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This fork is only here to stay until the fix in merged back into the main repo `
 - add following to the end of you composer.json object:
 ```json
 {
-    [...],
+    // ... ,
     "minimum-stability": "dev",
     "prefer-stable": true,
     "repositories": [

--- a/README.md
+++ b/README.md
@@ -4,6 +4,30 @@ A simple little field type that allows the user to select a single category from
 
 You can switch back and forth freely between this and the native Category field, as you needs change. Of course if you had multiple categories selected in the native field and you switch to Single Cat, the next time you save each entry you will lose all but the first associated category.
 
+# IMPORTANT NOTICE
+
+This fork is only here to stay until the fix in merged back into the main repo `elivz/craft-single-cat`.
+
+## Install Quickfix
+
+- go to your `composer.json` in your CraftCMS installation.
+- manually change the repo `elivz/craft-single-cat` &rarr; `"ynmstudio/craft-single-cat": "^1.2"`
+- add following to the end of you composer.json object:
+```json
+{
+    [...],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "repositories": [
+      {
+        "type": "vcs",
+        "url": "https://github.com/ynmstudio/craft-single-cat"
+      }
+    ]
+}
+```
+- run `composer update`
+
 ## Requirements
 
 This plugin requires Craft CMS 3.1 or later.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "elivz/craft-single-cat",
+  "name": "ynmstudio/craft-single-cat",
   "description": "Field type that allows the user to select a single category from a drop-down.",
   "type": "craft-plugin",
   "version": "1.2.2",

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,18 @@
     "single category"
   ],
   "support": {
-    "docs": "https://github.com/elivz/craft-single-cat/blob/master/README.md",
-    "issues": "https://github.com/elivz/craft-single-cat/issues"
+    "docs": "https://github.com/ynmstudio/craft-single-cat/blob/master/README.md",
+    "issues": "https://github.com/ynmstudio/craft-single-cat/issues"
   },
   "license": "MIT",
   "authors": [
     {
       "name": "Eli Van Zoeren",
       "homepage": "https://elivz.com"
+    },
+    {
+      "name": "Denis Yilmaz",
+      "homepage": "https://ynm.studio"
     }
   ],
   "require": {
@@ -33,7 +37,7 @@
   "extra": {
     "name": "Single Cat",
     "handle": "single-cat",
-    "changelogUrl": "https://raw.githubusercontent.com/elivz/craft-single-cat/master/CHANGELOG.md",
+    "changelogUrl": "https://raw.githubusercontent.com/ynmstudio/craft-single-cat/master/CHANGELOG.md",
     "class": "elivz\\singlecat\\SingleCat"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "ynmstudio/craft-single-cat",
+  "name": "elivz/craft-single-cat",
   "description": "Field type that allows the user to select a single category from a drop-down.",
   "type": "craft-plugin",
-  "version": "dev-1.2.1",
+  "version": "dev-1.2.2",
   "keywords": [
     "craftcms",
     "craft-plugin",
@@ -12,8 +12,8 @@
     "single category"
   ],
   "support": {
-    "docs": "https://github.com/ynmstudio/craft-single-cat/blob/master/README.md",
-    "issues": "https://github.com/ynmstudio/craft-single-cat/issues"
+    "docs": "https://github.com/elivz/craft-single-cat/blob/master/README.md",
+    "issues": "https://github.com/elivz/craft-single-cat/issues"
   },
   "license": "MIT",
   "authors": [
@@ -37,7 +37,7 @@
   "extra": {
     "name": "Single Cat",
     "handle": "single-cat",
-    "changelogUrl": "https://raw.githubusercontent.com/ynmstudio/craft-single-cat/master/CHANGELOG.md",
+    "changelogUrl": "https://raw.githubusercontent.com/elivz/craft-single-cat/master/CHANGELOG.md",
     "class": "elivz\\singlecat\\SingleCat"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ynmstudio/craft-single-cat",
   "description": "Field type that allows the user to select a single category from a drop-down.",
   "type": "craft-plugin",
-  "version": "1.2.2",
+  "version": "dev-1.2.1",
   "keywords": [
     "craftcms",
     "craft-plugin",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "elivz/craft-single-cat",
+  "name": "ynmstudio/craft-single-cat",
   "description": "Field type that allows the user to select a single category from a drop-down.",
   "type": "craft-plugin",
   "version": "dev-1.2.2",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "elivz/craft-single-cat",
   "description": "Field type that allows the user to select a single category from a drop-down.",
   "type": "craft-plugin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "keywords": [
     "craftcms",
     "craft-plugin",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ynmstudio/craft-single-cat",
   "description": "Field type that allows the user to select a single category from a drop-down.",
   "type": "craft-plugin",
-  "version": "dev-1.2.2",
+  "version": "1.2.2",
   "keywords": [
     "craftcms",
     "craft-plugin",


### PR DESCRIPTION
Currently GraphQL fails while querying for single-cat fields as it does not expect the `CategoryInterface` but rather a `String`.
I included the `getContentGqlType()` from the native categories fields from `CraftCMS 3.4.16` and its working for Queries.